### PR TITLE
Fix SettingsManager init and add validate_number

### DIFF
--- a/logic/utils.py
+++ b/logic/utils.py
@@ -13,6 +13,14 @@ def hash_password(password: str) -> str:
     """Hash a password using SHA256"""
     return hashlib.sha256(password.encode()).hexdigest()
 
+def validate_number(value: str) -> bool:
+    """Return True if the string represents a number"""
+    try:
+        float(value)
+        return True
+    except (ValueError, TypeError):
+        return False
+
 class POSUtils:
     @staticmethod
     def format_currency(amount: float) -> str:

--- a/ui/admin/expenses_screen.py
+++ b/ui/admin/expenses_screen.py
@@ -9,7 +9,7 @@ class ExpensesScreen:
     def __init__(self, parent, db_path):
         self.parent = parent
         self.db_path = db_path
-        self.settings_manager = SettingsManager(db_path)
+        self.settings_manager = SettingsManager()
         
         self.create_widgets()
         self.load_expenses()


### PR DESCRIPTION
## Summary
- add a simple `validate_number` helper
- instantiate SettingsManager without arguments

## Testing
- `python simple_test.py`

------
https://chatgpt.com/codex/tasks/task_e_684050c3c418832d82f82cd736fb1d46