### PR TITLE
Unify password hashing

### DIFF
--- a/db/init_db.py
+++ b/db/init_db.py
@@ -117,8 +117,8 @@ def initialize_database():
     # Create default admin user if no users exist
     cursor.execute('SELECT COUNT(*) FROM users')
     if cursor.fetchone()[0] == 0:
-        import hashlib
-        password_hash = hashlib.sha256('admin123'.encode()).hexdigest()
+        from logic.utils import hash_password
+        password_hash = hash_password('admin123')
         cursor.execute('''
             INSERT INTO users (username, password_hash, role, full_name)
             VALUES (?, ?, ?, ?)

--- a/logic/user_manager.py
+++ b/logic/user_manager.py
@@ -2,16 +2,16 @@
 User management logic with last_login support
 """
 
-import hashlib
 from typing import Optional, List, Dict
 from datetime import datetime
 from db.db_utils import execute_query_dict, execute_query
+from logic.utils import hash_password as utils_hash_password
 
 class UserManager:
     @staticmethod
     def hash_password(password: str) -> str:
         """Hash a password using SHA256"""
-        return hashlib.sha256(password.encode()).hexdigest()
+        return utils_hash_password(password)
     
     @staticmethod
     def authenticate_user(username: str, password: str) -> Optional[Dict]:


### PR DESCRIPTION
## Summary
- centralize password hashing via `logic.utils.hash_password`
- call the unified function from `UserManager`
- initialize admin password using the same utility

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684473baa85c832da9efd57728b3369e