### PR TITLE
Enable foreign key checks in UI modules

### DIFF
--- a/ui/admin/admin_panel.py
+++ b/ui/admin/admin_panel.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 import sqlite3
+from db.db_utils import get_db_connection
 from datetime import datetime, date
 import os
 import sys
@@ -336,7 +337,7 @@ class AdminPanel:
             self.orders_tree.delete(item)
 
         try:
-            conn = sqlite3.connect(self.db_path)
+            conn = get_db_connection()
             cursor = conn.cursor()
             query = '''
                 SELECT o.order_number,
@@ -402,7 +403,7 @@ class AdminPanel:
     def get_today_stats(self):
         """Get today's statistics from database"""
         try:
-            conn = sqlite3.connect(self.db_path)
+            conn = get_db_connection()
             cursor = conn.cursor()
             
             today = date.today().strftime('%Y-%m-%d')

--- a/ui/admin/expenses_screen.py
+++ b/ui/admin/expenses_screen.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 from datetime import datetime, date
 import sqlite3
+from db.db_utils import get_db_connection
 from logic.utils import validate_number
 from logic.settings_manager import SettingsManager
 
@@ -161,7 +162,7 @@ class ExpensesScreen:
             return
             
         try:
-            conn = sqlite3.connect(self.db_path)
+            conn = get_db_connection()
             cursor = conn.cursor()
             
             cursor.execute('''
@@ -193,7 +194,7 @@ class ExpensesScreen:
             self.tree.delete(item)
             
         try:
-            conn = sqlite3.connect(self.db_path)
+            conn = get_db_connection()
             cursor = conn.cursor()
             
             # Build query with filters
@@ -259,7 +260,7 @@ class ExpensesScreen:
         
         # Get current expense data
         try:
-            conn = sqlite3.connect(self.db_path)
+            conn = get_db_connection()
             cursor = conn.cursor()
             cursor.execute("SELECT description, amount, category, date FROM expenses WHERE id = ?", (expense_id,))
             expense_data = cursor.fetchone()
@@ -330,7 +331,7 @@ class ExpensesScreen:
                 return
                 
             try:
-                conn = sqlite3.connect(self.db_path)
+                conn = get_db_connection()
                 cursor = conn.cursor()
                 
                 cursor.execute('''
@@ -365,7 +366,7 @@ class ExpensesScreen:
         
         if messagebox.askyesno("Confirm Delete", f"Are you sure you want to delete the expense '{description}'?"):
             try:
-                conn = sqlite3.connect(self.db_path)
+                conn = get_db_connection()
                 cursor = conn.cursor()
                 
                 cursor.execute("DELETE FROM expenses WHERE id = ?", (expense_id,))

--- a/ui/admin/user_management.py
+++ b/ui/admin/user_management.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 import sqlite3
+from db.db_utils import get_db_connection
 from logic.user_manager import UserManager
 from logic.utils import hash_password
 
@@ -174,7 +175,7 @@ class UserManagement:
             
         # Check if username already exists
         try:
-            conn = sqlite3.connect(self.db_path)
+            conn = get_db_connection()
             cursor = conn.cursor()
             cursor.execute("SELECT id FROM users WHERE username = ?", (username,))
             if cursor.fetchone():
@@ -210,7 +211,7 @@ class UserManagement:
             self.tree.delete(item)
             
         try:
-            conn = sqlite3.connect(self.db_path)
+            conn = get_db_connection()
             cursor = conn.cursor()
             
             # Build query with filters
@@ -271,7 +272,7 @@ class UserManagement:
         
         # Get current user data
         try:
-            conn = sqlite3.connect(self.db_path)
+            conn = get_db_connection()
             cursor = conn.cursor()
             cursor.execute("SELECT username, full_name, email, role, is_active FROM users WHERE id = ?", (user_id,))
             user_data = cursor.fetchone()
@@ -339,7 +340,7 @@ class UserManagement:
                 return
                 
             try:
-                conn = sqlite3.connect(self.db_path)
+                conn = get_db_connection()
                 cursor = conn.cursor()
                 
                 cursor.execute('''
@@ -377,7 +378,7 @@ class UserManagement:
         
         if messagebox.askyesno("Confirm", f"Change {username}'s status to {new_status}?"):
             try:
-                conn = sqlite3.connect(self.db_path)
+                conn = get_db_connection()
                 cursor = conn.cursor()
                 
                 new_active = 1 if new_status == "Active" else 0
@@ -448,7 +449,7 @@ class UserManagement:
                 return
                 
             try:
-                conn = sqlite3.connect(self.db_path)
+                conn = get_db_connection()
                 cursor = conn.cursor()
                 
                 hashed_password = hash_password(new_password)
@@ -479,7 +480,7 @@ class UserManagement:
         
         if messagebox.askyesno("Confirm Delete", f"Are you sure you want to delete user '{username}'?\n\nThis action cannot be undone."):
             try:
-                conn = sqlite3.connect(self.db_path)
+                conn = get_db_connection()
                 cursor = conn.cursor()
                 
                 # Check if this is the last admin user


### PR DESCRIPTION
## Summary
- ensure UI modules enable SQLite foreign keys by using `get_db_connection`
- update admin_panel, expenses_screen and user_management modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684473ae3860832db9d590d17c045d5b